### PR TITLE
Remove public enum reexports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,23 +127,23 @@ pub mod color {
     /// Number for a terminal color
     pub type Color = u16;
 
-    pub const BLACK:   Color = 0u16;
-    pub const RED:     Color = 1u16;
-    pub const GREEN:   Color = 2u16;
-    pub const YELLOW:  Color = 3u16;
-    pub const BLUE:    Color = 4u16;
-    pub const MAGENTA: Color = 5u16;
-    pub const CYAN:    Color = 6u16;
-    pub const WHITE:   Color = 7u16;
+    pub const BLACK:   Color = 0;
+    pub const RED:     Color = 1;
+    pub const GREEN:   Color = 2;
+    pub const YELLOW:  Color = 3;
+    pub const BLUE:    Color = 4;
+    pub const MAGENTA: Color = 5;
+    pub const CYAN:    Color = 6;
+    pub const WHITE:   Color = 7;
 
-    pub const BRIGHT_BLACK:   Color = 8u16;
-    pub const BRIGHT_RED:     Color = 9u16;
-    pub const BRIGHT_GREEN:   Color = 10u16;
-    pub const BRIGHT_YELLOW:  Color = 11u16;
-    pub const BRIGHT_BLUE:    Color = 12u16;
-    pub const BRIGHT_MAGENTA: Color = 13u16;
-    pub const BRIGHT_CYAN:    Color = 14u16;
-    pub const BRIGHT_WHITE:   Color = 15u16;
+    pub const BRIGHT_BLACK:   Color = 8;
+    pub const BRIGHT_RED:     Color = 9;
+    pub const BRIGHT_GREEN:   Color = 10;
+    pub const BRIGHT_YELLOW:  Color = 11;
+    pub const BRIGHT_BLUE:    Color = 12;
+    pub const BRIGHT_MAGENTA: Color = 13;
+    pub const BRIGHT_CYAN:    Color = 14;
+    pub const BRIGHT_WHITE:   Color = 15;
 }
 
 /// Terminal attributes for use with term.attr().

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,38 +146,33 @@ pub mod color {
     pub const BRIGHT_WHITE:   Color = 15u16;
 }
 
-/// Terminal attributes
-pub mod attr {
-    pub use self::Attr::*;
-
-    /// Terminal attributes for use with term.attr().
-    ///
-    /// Most attributes can only be turned on and must be turned off with term.reset().
-    /// The ones that can be turned off explicitly take a boolean value.
-    /// Color is also represented as an attribute for convenience.
-    #[derive(Copy)]
-    pub enum Attr {
-        /// Bold (or possibly bright) mode
-        Bold,
-        /// Dim mode, also called faint or half-bright. Often not supported
-        Dim,
-        /// Italics mode. Often not supported
-        Italic(bool),
-        /// Underline mode
-        Underline(bool),
-        /// Blink mode
-        Blink,
-        /// Standout mode. Often implemented as Reverse, sometimes coupled with Bold
-        Standout(bool),
-        /// Reverse mode, inverts the foreground and background colors
-        Reverse,
-        /// Secure mode, also called invis mode. Hides the printed text
-        Secure,
-        /// Convenience attribute to set the foreground color
-        ForegroundColor(super::color::Color),
-        /// Convenience attribute to set the background color
-        BackgroundColor(super::color::Color)
-    }
+/// Terminal attributes for use with term.attr().
+///
+/// Most attributes can only be turned on and must be turned off with term.reset().
+/// The ones that can be turned off explicitly take a boolean value.
+/// Color is also represented as an attribute for convenience.
+#[derive(Copy)]
+pub enum Attr {
+    /// Bold (or possibly bright) mode
+    Bold,
+    /// Dim mode, also called faint or half-bright. Often not supported
+    Dim,
+    /// Italics mode. Often not supported
+    Italic(bool),
+    /// Underline mode
+    Underline(bool),
+    /// Blink mode
+    Blink,
+    /// Standout mode. Often implemented as Reverse, sometimes coupled with Bold
+    Standout(bool),
+    /// Reverse mode, inverts the foreground and background colors
+    Reverse,
+    /// Secure mode, also called invis mode. Hides the printed text
+    Secure,
+    /// Convenience attribute to set the foreground color
+    ForegroundColor(color::Color),
+    /// Convenience attribute to set the background color
+    BackgroundColor(color::Color)
 }
 
 /// A terminal with similar capabilities to an ANSI Terminal
@@ -204,10 +199,10 @@ pub trait Terminal<T: Writer>: Writer {
     /// Sets the given terminal attribute, if supported.  Returns `Ok(true)`
     /// if the attribute was supported, `Ok(false)` otherwise, and `Err(e)` if
     /// there was an I/O error.
-    fn attr(&mut self, attr: attr::Attr) -> IoResult<bool>;
+    fn attr(&mut self, attr: Attr) -> IoResult<bool>;
 
     /// Returns whether the given terminal attribute is supported.
-    fn supports_attr(&self, attr: attr::Attr) -> bool;
+    fn supports_attr(&self, attr: Attr) -> bool;
 
     /// Resets all terminal attributes and color to the default.
     /// Returns `Ok()`.

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -14,13 +14,14 @@ use std::collections::HashMap;
 use std::io::IoResult;
 use std::os;
 
-use attr;
+use Attr;
 use color;
 use Terminal;
 use UnwrappableTerminal;
 use self::searcher::open;
 use self::parser::compiled::{parse, msys_terminfo};
-use self::parm::{expand, Number, Variables};
+use self::parm::{expand, Variables};
+use self::parm::Param::Number;
 
 
 /// A parsed terminfo database entry.
@@ -46,21 +47,21 @@ pub mod parser {
 pub mod parm;
 
 
-fn cap_for_attr(attr: attr::Attr) -> &'static str {
+fn cap_for_attr(attr: Attr) -> &'static str {
     match attr {
-        attr::Bold               => "bold",
-        attr::Dim                => "dim",
-        attr::Italic(true)       => "sitm",
-        attr::Italic(false)      => "ritm",
-        attr::Underline(true)    => "smul",
-        attr::Underline(false)   => "rmul",
-        attr::Blink              => "blink",
-        attr::Standout(true)     => "smso",
-        attr::Standout(false)    => "rmso",
-        attr::Reverse            => "rev",
-        attr::Secure             => "invis",
-        attr::ForegroundColor(_) => "setaf",
-        attr::BackgroundColor(_) => "setab"
+        Attr::Bold               => "bold",
+        Attr::Dim                => "dim",
+        Attr::Italic(true)       => "sitm",
+        Attr::Italic(false)      => "ritm",
+        Attr::Underline(true)    => "smul",
+        Attr::Underline(false)   => "rmul",
+        Attr::Blink              => "blink",
+        Attr::Standout(true)     => "smso",
+        Attr::Standout(false)    => "rmso",
+        Attr::Reverse            => "rev",
+        Attr::Secure             => "invis",
+        Attr::ForegroundColor(_) => "setaf",
+        Attr::BackgroundColor(_) => "setab"
     }
 }
 
@@ -107,10 +108,10 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
         Ok(false)
     }
 
-    fn attr(&mut self, attr: attr::Attr) -> IoResult<bool> {
+    fn attr(&mut self, attr: Attr) -> IoResult<bool> {
         match attr {
-            attr::ForegroundColor(c) => self.fg(c),
-            attr::BackgroundColor(c) => self.bg(c),
+            Attr::ForegroundColor(c) => self.fg(c),
+            Attr::BackgroundColor(c) => self.bg(c),
             _ => {
                 let cap = cap_for_attr(attr);
                 let parm = self.ti.strings.get(cap);
@@ -128,9 +129,9 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
         }
     }
 
-    fn supports_attr(&self, attr: attr::Attr) -> bool {
+    fn supports_attr(&self, attr: Attr) -> bool {
         match attr {
-            attr::ForegroundColor(_) | attr::BackgroundColor(_) => {
+            Attr::ForegroundColor(_) | Attr::BackgroundColor(_) => {
                 self.num_colors > 0
             }
             _ => {

--- a/src/terminfo/parm.rs
+++ b/src/terminfo/parm.rs
@@ -10,7 +10,7 @@
 
 //! Parameterized string expansion
 
-pub use self::Param::*;
+use self::Param::*;
 use self::States::*;
 use self::FormatState::*;
 use self::FormatOp::*;
@@ -574,7 +574,8 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
 
 #[cfg(test)]
 mod test {
-    use super::{expand,Param,Words,Variables,Number};
+    use super::{expand, Variables};
+    use super::Param::{self, Words, Number};
     use std::result::Result::Ok;
 
     #[test]


### PR DESCRIPTION
These were probably left over from pre-enum-namespacing

[breaking-change]