### PR TITLE
Correctly report failed resets.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!     t.fg(term::color::RED).unwrap();
 //!     (writeln!(t, "world!")).unwrap();
 //!
-//!     t.reset().unwrap();
+//!     assert!(t.reset().unwrap());
 //! }
 //! ```
 //!
@@ -198,8 +198,10 @@ pub trait Terminal<T: Writer>: Writer {
     fn supports_attr(&self, attr: Attr) -> bool;
 
     /// Resets all terminal attributes and color to the default.
-    /// Returns `Ok()`.
-    fn reset(&mut self) -> IoResult<()>;
+    ///
+    /// Returns `Ok(true)` if the terminal was reset, `Ok(false)` otherwise, and `Err(e)` if there
+    /// was an I/O error.
+    fn reset(&mut self) -> IoResult<bool>;
 
     /// Gets an immutable reference to the stream inside
     fn get_ref<'a>(&'a self) -> &'a T;

--- a/src/win.rs
+++ b/src/win.rs
@@ -179,12 +179,12 @@ impl<T: Writer+Send> Terminal<T> for WinConsole<T> {
         }
     }
 
-    fn reset(&mut self) -> IoResult<()> {
+    fn reset(&mut self) -> IoResult<bool> {
         self.foreground = self.def_foreground;
         self.background = self.def_background;
         self.apply();
 
-        Ok(())
+        Ok(true)
     }
 
     fn get_ref<'a>(&'a self) -> &'a T { &self.buf }


### PR DESCRIPTION
Instead of always returning `Ok(())`, return `Ok(false)` when reset is unsupported, `Ok(true)` when it succeeds, and `Err(e)` when there is an IoError. Additionally, cleanup the reset function a little.

This is a [breaking-change].
