### PR TITLE
Avoid unnecessarily boxing

### DIFF
--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -69,7 +69,7 @@ fn cap_for_attr(attr: Attr) -> &'static str {
 pub struct TerminfoTerminal<T> {
     num_colors: u16,
     out: T,
-    ti: Box<TermInfo>
+    ti: TermInfo,
 }
 
 impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
@@ -139,7 +139,7 @@ impl<T: Writer+Send> UnwrappableTerminal<T> for TerminfoTerminal<T> {
 impl<T: Writer+Send> TerminfoTerminal<T> {
     /// Returns `None` whenever the terminal cannot be created for some
     /// reason.
-    pub fn new(out: T) -> Option<Box<Terminal<T>+Send+'static>> {
+    pub fn new(out: T) -> Option<TerminfoTerminal<T>> {
         let term = match os::getenv("TERM") {
             Some(t) => t,
             None => {
@@ -154,9 +154,11 @@ impl<T: Writer+Send> TerminfoTerminal<T> {
                     "mintty.exe" == s
                 }) {
                 // msys terminal
-                return Some(Box::new(TerminfoTerminal {out: out,
-                                                       ti: msys_terminfo(),
-                                                       num_colors: 8}) as Box<Terminal<T>+Send>);
+                return Some(TerminfoTerminal {
+                    out: out,
+                    ti: msys_terminfo(),
+                    num_colors: 8
+                });
             }
             debug!("error finding terminfo entry: {}", entry.err().unwrap());
             return None;
@@ -175,9 +177,11 @@ impl<T: Writer+Send> TerminfoTerminal<T> {
                      inf.numbers.get("colors").map_or(0, |&n| n)
                  } else { 0 };
 
-        return Some(Box::new(TerminfoTerminal {out: out,
-                                               ti: inf,
-                                               num_colors: nc}) as Box<Terminal<T>+Send>);
+        return Some(TerminfoTerminal {
+            out: out,
+            ti: inf,
+            num_colors: nc
+        });
     }
 
     fn dim_if_necessary(&self, color: color::Color) -> color::Color {

--- a/src/terminfo/parser/compiled.rs
+++ b/src/terminfo/parser/compiled.rs
@@ -159,7 +159,7 @@ pub static stringnames: &'static[&'static str] = &[ "cbt", "_", "cr", "csr", "tb
 
 /// Parse a compiled terminfo entry, using long capability names if `longnames` is true
 pub fn parse(file: &mut io::Reader, longnames: bool)
-             -> Result<Box<TermInfo>, String> {
+             -> Result<TermInfo, String> {
     macro_rules! try( ($e:expr) => (
         match $e {
             Ok(e) => e,
@@ -293,27 +293,27 @@ pub fn parse(file: &mut io::Reader, longnames: bool)
     }
 
     // And that's all there is to it
-    Ok(Box::new(TermInfo {
+    Ok(TermInfo {
         names: term_names,
         bools: bools_map,
         numbers: numbers_map,
         strings: string_map
-    }))
+    })
 }
 
 /// Create a dummy TermInfo struct for msys terminals
-pub fn msys_terminfo() -> Box<TermInfo> {
+pub fn msys_terminfo() -> TermInfo {
     let mut strings = HashMap::new();
     strings.insert("sgr0".to_string(), b"\x1B[0m".to_vec());
     strings.insert("bold".to_string(), b"\x1B[1m".to_vec());
     strings.insert("setaf".to_string(), b"\x1B[3%p1%dm".to_vec());
     strings.insert("setab".to_string(), b"\x1B[4%p1%dm".to_vec());
-    Box::new(TermInfo {
+    TermInfo {
         names: vec!("cygwin".to_string()), // msys is a fork of an older cygwin version
         bools: HashMap::new(),
         numbers: HashMap::new(),
         strings: strings
-    })
+    }
 }
 
 #[cfg(test)]

--- a/src/terminfo/searcher.rs
+++ b/src/terminfo/searcher.rs
@@ -18,7 +18,7 @@ use std::os::getenv;
 use std::os;
 
 /// Return path to database entry for `term`
-pub fn get_dbpath_for_term(term: &str) -> Option<Box<Path>> {
+pub fn get_dbpath_for_term(term: &str) -> Option<Path> {
     if term.len() == 0 {
         return None;
     }
@@ -63,13 +63,13 @@ pub fn get_dbpath_for_term(term: &str) -> Option<Box<Path>> {
             let f = first_char.to_string();
             let newp = p.join_many(&[&f[], term]);
             if newp.exists() {
-                return Some(Box::new(newp));
+                return Some(newp);
             }
             // on some installations the dir is named after the hex of the char (e.g. OS X)
             let f = format!("{:x}", first_char as uint);
             let newp = p.join_many(&[&f[], term]);
             if newp.exists() {
-                return Some(Box::new(newp));
+                return Some(newp);
             }
         }
     }
@@ -80,7 +80,7 @@ pub fn get_dbpath_for_term(term: &str) -> Option<Box<Path>> {
 pub fn open(term: &str) -> Result<File, String> {
     match get_dbpath_for_term(term) {
         Some(x) => {
-            match File::open(&*x) {
+            match File::open(&x) {
                 Ok(file) => Ok(file),
                 Err(e) => Err(format!("error opening file: {}", e)),
             }

--- a/src/win.rs
+++ b/src/win.rs
@@ -110,7 +110,7 @@ impl<T: Writer+Send> WinConsole<T> {
 
     /// Returns `None` whenever the terminal cannot be created for some
     /// reason.
-    pub fn new(out: T) -> Option<Box<Terminal<T>+Send+'static>> {
+    pub fn new(out: T) -> Option<Winconsole<T>> {
         let fg;
         let bg;
         unsafe {
@@ -123,9 +123,13 @@ impl<T: Writer+Send> WinConsole<T> {
                 bg = color::BLACK;
             }
         }
-        Some(Box::new(WinConsole { buf: out,
-                                   def_foreground: fg, def_background: bg,
-                                   foreground: fg, background: bg }) as Box<Terminal<T>+Send>)
+        Some(WinConsole {
+            buf: out,
+            def_foreground: fg,
+            def_background: bg,
+            foreground: fg,
+            background: bg,
+        })
     }
 }
 


### PR DESCRIPTION
This excessive boxing appears to be left over from ~T days and doesn't appear to provide any real benefit as far as I can tell(?). This is a [breaking-change] and will affect rustc because rustc hardcodes the `stdout()` return type (I changed it to a type alias to hopefully avoid this in the future).