### PR TITLE
Attr: derive a few more traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ pub mod color {
 /// Most attributes can only be turned on and must be turned off with term.reset().
 /// The ones that can be turned off explicitly take a boolean value.
 /// Color is also represented as an attribute for convenience.
-#[derive(Copy)]
+#[derive(Show, PartialEq, Eq, Copy)]
 pub enum Attr {
     /// Bold (or possibly bright) mode
     Bold,


### PR DESCRIPTION
This is for use in downstream library which want to reference Attr type,
but need it to implement more traits.

One example is 'bread':
https://github.com/mkpankov/bread