### PR TITLE
Update to nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ A terminal formatting library
 """
 
 [dependencies]
-log = "0.1.0"
+log = "0.2.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,6 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/",
        html_playground_url = "http://play.rust-lang.org/")]
-#![feature(int_uint)]
 #![deny(missing_docs)]
 #![allow(unstable)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
        html_root_url = "http://doc.rust-lang.org/nightly/",
        html_playground_url = "http://play.rust-lang.org/")]
 #![deny(missing_docs)]
-#![allow(unstable)]
+#![feature(core, io, os, collections, std_misc, path, unicode)]
 
 #[macro_use] extern crate log;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,9 @@ pub use terminfo::TerminfoTerminal;
 #[cfg(windows)]
 pub use win::WinConsole;
 
-use std::io::{IoResult, LineBufferedWriter};
-use std::io::stdio::StdWriter;
+use std::old_io::{IoResult, LineBufferedWriter};
+use std::old_io::stdio::StdWriter;
+use std::old_io as io;
 
 pub mod terminfo;
 
@@ -68,7 +69,7 @@ pub type StdTerminal = Terminal<LineBufferedWriter<StdWriter>> + Send;
 /// Return a Terminal wrapping stdout, or None if a terminal couldn't be
 /// opened.
 pub fn stdout() -> Option<Box<StdTerminal>> {
-    TerminfoTerminal::new(std::io::stdout()).map(|t| {
+    TerminfoTerminal::new(io::stdout()).map(|t| {
         Box::new(t) as Box<StdTerminal>
     })
 }
@@ -77,9 +78,9 @@ pub fn stdout() -> Option<Box<StdTerminal>> {
 /// Return a Terminal wrapping stdout, or None if a terminal couldn't be
 /// opened.
 pub fn stdout() -> Option<Box<StdTerminal>> {
-    TerminfoTerminal::new(std::io::stdout()).map(|t| {
+    TerminfoTerminal::new(io::stdout()).map(|t| {
         Box::new(t) as Box<StdTerminal>
-    }).or_else(|| WinConsole::new(std::io::stdout()).map(|t| {
+    }).or_else(|| WinConsole::new(io::stdout()).map(|t| {
         Box::new(t) as Box<StdTerminal>
     }))
 }
@@ -88,7 +89,7 @@ pub fn stdout() -> Option<Box<StdTerminal>> {
 /// Return a Terminal wrapping stderr, or None if a terminal couldn't be
 /// opened.
 pub fn stderr() -> Option<Box<StdTerminal>> {
-    TerminfoTerminal::new(std::io::stderr()).map(|t| {
+    TerminfoTerminal::new(io::stderr()).map(|t| {
         Box::new(t) as Box<StdTerminal>
     })
 }
@@ -97,9 +98,9 @@ pub fn stderr() -> Option<Box<StdTerminal>> {
 /// Return a Terminal wrapping stderr, or None if a terminal couldn't be
 /// opened.
 pub fn stderr() -> Option<Box<StdTerminal>> {
-    TerminfoTerminal::new(std::io::stderr()).map(|t| {
+    TerminfoTerminal::new(io::stderr()).map(|t| {
         Box::new(t) as Box<StdTerminal>
-    }).or_else(|| WinConsole::new(std::io::stderr()).map(|t| {
+    }).or_else(|| WinConsole::new(io::stderr()).map(|t| {
         Box::new(t) as Box<StdTerminal>
     }))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ pub mod color {
 /// Most attributes can only be turned on and must be turned off with term.reset().
 /// The ones that can be turned off explicitly take a boolean value.
 /// Color is also represented as an attribute for convenience.
-#[derive(Show, PartialEq, Eq, Copy)]
+#[derive(Debug, PartialEq, Eq, Copy)]
 pub enum Attr {
     /// Bold (or possibly bright) mode
     Bold,

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -15,6 +15,7 @@ use std::error::Error as ErrorTrait;
 use std::old_io::{IoError, IoErrorKind, IoResult, File};
 use std::old_io as io;
 use std::os;
+use std::fmt;
 
 use Attr;
 use color;
@@ -26,7 +27,7 @@ use self::parm::{expand, Variables, Param};
 
 
 /// A parsed terminfo database entry.
-#[derive(Show)]
+#[derive(Debug)]
 pub struct TermInfo {
     /// Names for the terminal
     pub names: Vec<String> ,
@@ -52,20 +53,28 @@ pub enum Error {
 impl ErrorTrait for Error {
     fn description(&self) -> &str { "failed to create TermInfo" }
 
-    fn detail(&self) -> Option<String> {
-        use self::Error::*;
-        match self {
-            &TermUnset => None,
-            &MalformedTerminfo(ref e) => Some(e.clone()),
-            &IoError(ref e) => e.detail()
-        }
-    }
-
     fn cause(&self) -> Option<&ErrorTrait> {
         use self::Error::*;
         match self {
             &IoError(ref e) => Some(e),
             _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        use self::Error::*;
+        match self {
+            &TermUnset => write!(
+                formatter,
+                "Terminfo database could not be found: TERM environment variable not set."),
+            &MalformedTerminfo(ref e) => write!(
+                formatter,
+                "Terminfo database parsing failed: {}", e),
+            &IoError(ref e) => write!(
+                formatter,
+                "Terminfo database parsing failed due to IO Error: {}", e)
         }
     }
 }

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -204,7 +204,7 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
             None => return Ok(false),
         };
 
-        self.out.write(&cmd[]).map(|_|true)
+        self.out.write_all(&cmd[]).map(|_|true)
     }
 
     fn get_ref<'a>(&'a self) -> &'a T { &self.out }
@@ -247,7 +247,7 @@ impl<T: Writer+Send> TerminfoTerminal<T> {
     fn apply_cap(&mut self, cmd: &str, params: &[Param]) -> IoResult<bool> {
         if let Some(cmd) = self.ti.strings.get(cmd) {
             if let Ok(s) = expand(cmd.as_slice(), params, &mut Variables::new()) {
-                try!(self.out.write(s.as_slice()));
+                try!(self.out.write_all(s.as_slice()));
                 return Ok(true)
             }
         }
@@ -257,12 +257,8 @@ impl<T: Writer+Send> TerminfoTerminal<T> {
 
 
 impl<T: Writer> Writer for TerminfoTerminal<T> {
-    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
-        self.out.write(buf)
-    }
-
     fn write_all(&mut self, buf: &[u8]) -> IoResult<()> {
-        self.out.write(buf)
+        self.out.write_all(buf)
     }
 
     fn flush(&mut self) -> IoResult<()> {

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -12,7 +12,8 @@
 
 use std::collections::HashMap;
 use std::error::Error as ErrorTrait;
-use std::io::{self, IoError, IoErrorKind, IoResult, File};
+use std::old_io::{IoError, IoErrorKind, IoResult, File};
+use std::old_io as io;
 use std::os;
 
 use Attr;
@@ -248,6 +249,10 @@ impl<T: Writer+Send> TerminfoTerminal<T> {
 
 impl<T: Writer> Writer for TerminfoTerminal<T> {
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
+        self.out.write(buf)
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> IoResult<()> {
         self.out.write(buf)
     }
 

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -156,7 +156,7 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
     fn fg(&mut self, color: color::Color) -> IoResult<bool> {
         let color = self.dim_if_necessary(color);
         if self.num_colors > color {
-            return self.apply_cap("setaf", &[Param::Number(color as int)]);
+            return self.apply_cap("setaf", &[Param::Number(color as isize)]);
         }
         Ok(false)
     }
@@ -164,7 +164,7 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
     fn bg(&mut self, color: color::Color) -> IoResult<bool> {
         let color = self.dim_if_necessary(color);
         if self.num_colors > color {
-            return self.apply_cap("setab", &[Param::Number(color as int)]);
+            return self.apply_cap("setab", &[Param::Number(color as isize)]);
         }
         Ok(false)
     }

--- a/src/terminfo/parm.rs
+++ b/src/terminfo/parm.rs
@@ -28,12 +28,12 @@ enum States {
     PushParam,
     CharConstant,
     CharClose,
-    IntConstant(int),
+    IntConstant(isize),
     FormatPattern(Flags, FormatState),
-    SeekIfElse(int),
-    SeekIfElsePercent(int),
-    SeekIfEnd(int),
-    SeekIfEndPercent(int)
+    SeekIfElse(isize),
+    SeekIfElsePercent(isize),
+    SeekIfEnd(isize),
+    SeekIfEndPercent(isize)
 }
 
 #[derive(Copy, PartialEq)]
@@ -48,7 +48,7 @@ enum FormatState {
 #[derive(Clone)]
 pub enum Param {
     Words(String),
-    Number(int)
+    Number(isize)
 }
 
 /// Container for static and dynamic variable arrays
@@ -144,7 +144,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     '{' => state = IntConstant(0),
                     'l' => if stack.len() > 0 {
                         match stack.pop().unwrap() {
-                            Words(s) => stack.push(Number(s.len() as int)),
+                            Words(s) => stack.push(Number(s.len() as isize)),
                             _        => return Err("a non-str was used with %l".to_string())
                         }
                     } else { return Err("stack is empty".to_string()) },
@@ -269,7 +269,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                             ' ' => flags.space = true,
                             '.' => fstate = FormatStatePrecision,
                             '0'...'9' => {
-                                flags.width = cur as uint - '0' as uint;
+                                flags.width = cur as usize - '0' as usize;
                                 fstate = FormatStateWidth;
                             }
                             _ => unreachable!()
@@ -306,12 +306,12 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                 if cur >= 'A' && cur <= 'Z' {
                     if stack.len() > 0 {
                         let idx = (cur as u8) - b'A';
-                        vars.sta[idx as uint] = stack.pop().unwrap();
+                        vars.sta[idx as usize] = stack.pop().unwrap();
                     } else { return Err("stack is empty".to_string()) }
                 } else if cur >= 'a' && cur <= 'z' {
                     if stack.len() > 0 {
                         let idx = (cur as u8) - b'a';
-                        vars.dyn[idx as uint] = stack.pop().unwrap();
+                        vars.dyn[idx as usize] = stack.pop().unwrap();
                     } else { return Err("stack is empty".to_string()) }
                 } else {
                     return Err("bad variable name in %P".to_string());
@@ -320,16 +320,16 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
             GetVar => {
                 if cur >= 'A' && cur <= 'Z' {
                     let idx = (cur as u8) - b'A';
-                    stack.push(vars.sta[idx as uint].clone());
+                    stack.push(vars.sta[idx as usize].clone());
                 } else if cur >= 'a' && cur <= 'z' {
                     let idx = (cur as u8) - b'a';
-                    stack.push(vars.dyn[idx as uint].clone());
+                    stack.push(vars.dyn[idx as usize].clone());
                 } else {
                     return Err("bad variable name in %g".to_string());
                 }
             },
             CharConstant => {
-                stack.push(Number(c as int));
+                stack.push(Number(c as isize));
                 state = CharClose;
             },
             CharClose => {
@@ -344,10 +344,10 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                         state = Nothing;
                     }
                     '0'...'9' => {
-                        state = IntConstant(i*10 + (cur as int - '0' as int));
+                        state = IntConstant(i*10 + (cur as isize - '0' as isize));
                         old_state = Nothing;
                     }
-                    _ => return Err("bad int constant".to_string())
+                    _ => return Err("bad isize constant".to_string())
                 }
             }
             FormatPattern(ref mut flags, ref mut fstate) => {
@@ -373,7 +373,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                         flags.space = true;
                     }
                     (FormatStateFlags,'0'...'9') => {
-                        flags.width = cur as uint - '0' as uint;
+                        flags.width = cur as usize - '0' as usize;
                         *fstate = FormatStateWidth;
                     }
                     (FormatStateFlags,'.') => {
@@ -381,7 +381,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     }
                     (FormatStateWidth,'0'...'9') => {
                         let old = flags.width;
-                        flags.width = flags.width * 10 + (cur as uint - '0' as uint);
+                        flags.width = flags.width * 10 + (cur as usize - '0' as usize);
                         if flags.width < old { return Err("format width overflow".to_string()) }
                     }
                     (FormatStateWidth,'.') => {
@@ -389,7 +389,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     }
                     (FormatStatePrecision,'0'...'9') => {
                         let old = flags.precision;
-                        flags.precision = flags.precision * 10 + (cur as uint - '0' as uint);
+                        flags.precision = flags.precision * 10 + (cur as usize - '0' as usize);
                         if flags.precision < old {
                             return Err("format precision overflow".to_string())
                         }
@@ -447,8 +447,8 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
 
 #[derive(Copy, PartialEq)]
 struct Flags {
-    width: uint,
-    precision: uint,
+    width: usize,
+    precision: usize,
     alternate: bool,
     left: bool,
     sign: bool,

--- a/src/terminfo/parser/compiled.rs
+++ b/src/terminfo/parser/compiled.rs
@@ -13,7 +13,7 @@
 //! ncurses-compatible compiled terminfo format parsing (term(5))
 
 use std::collections::HashMap;
-use std::io;
+use std::old_io as io;
 use super::super::TermInfo;
 
 // These are the orders ncurses uses in its compiled format (as of 5.9). Not sure if portable.

--- a/src/terminfo/parser/compiled.rs
+++ b/src/terminfo/parser/compiled.rs
@@ -180,31 +180,31 @@ pub fn parse(file: &mut io::Reader, longnames: bool)
                            0x011A_us, magic as usize));
     }
 
-    let names_bytes          = try!(file.read_le_i16()) as int;
-    let bools_bytes          = try!(file.read_le_i16()) as int;
-    let numbers_count        = try!(file.read_le_i16()) as int;
-    let string_offsets_count = try!(file.read_le_i16()) as int;
-    let string_table_bytes   = try!(file.read_le_i16()) as int;
+    let names_bytes          = try!(file.read_le_i16()) as isize;
+    let bools_bytes          = try!(file.read_le_i16()) as isize;
+    let numbers_count        = try!(file.read_le_i16()) as isize;
+    let string_offsets_count = try!(file.read_le_i16()) as isize;
+    let string_table_bytes   = try!(file.read_le_i16()) as isize;
 
     assert!(names_bytes > 0);
 
-    if (bools_bytes as uint) > boolnames.len() {
+    if (bools_bytes as usize) > boolnames.len() {
         return Err("incompatible file: more booleans than \
                     expected".to_string());
     }
 
-    if (numbers_count as uint) > numnames.len() {
+    if (numbers_count as usize) > numnames.len() {
         return Err("incompatible file: more numbers than \
                     expected".to_string());
     }
 
-    if (string_offsets_count as uint) > stringnames.len() {
+    if (string_offsets_count as usize) > stringnames.len() {
         return Err("incompatible file: more string offsets than \
                     expected".to_string());
     }
 
     // don't read NUL
-    let bytes = try!(file.read_exact(names_bytes as uint - 1));
+    let bytes = try!(file.read_exact(names_bytes as usize - 1));
     let names_str = match String::from_utf8(bytes) {
         Ok(s)  => s,
         Err(_) => return Err("input not utf-8".to_string()),
@@ -221,7 +221,7 @@ pub fn parse(file: &mut io::Reader, longnames: bool)
         for i in range(0, bools_bytes) {
             let b = try!(file.read_byte());
             if b == 1 {
-                bools_map.insert(bnames[i as uint].to_string(), true);
+                bools_map.insert(bnames[i as usize].to_string(), true);
             }
         }
     }
@@ -235,7 +235,7 @@ pub fn parse(file: &mut io::Reader, longnames: bool)
         for i in range(0, numbers_count) {
             let n = try!(file.read_le_u16());
             if n != 0xFFFF {
-                numbers_map.insert(nnames[i as uint].to_string(), n);
+                numbers_map.insert(nnames[i as usize].to_string(), n);
             }
         }
     }
@@ -248,9 +248,9 @@ pub fn parse(file: &mut io::Reader, longnames: bool)
             string_offsets.push(try!(file.read_le_u16()));
         }
 
-        let string_table = try!(file.read_exact(string_table_bytes as uint));
+        let string_table = try!(file.read_exact(string_table_bytes as usize));
 
-        if string_table.len() != string_table_bytes as uint {
+        if string_table.len() != string_table_bytes as usize {
             return Err("error: hit EOF before end of string \
                         table".to_string());
         }
@@ -276,13 +276,13 @@ pub fn parse(file: &mut io::Reader, longnames: bool)
 
 
             // Find the offset of the NUL we want to go to
-            let nulpos = string_table[offset as uint .. string_table_bytes as uint]
+            let nulpos = string_table[offset as usize .. string_table_bytes as usize]
                 .iter().position(|&b| b == 0);
             match nulpos {
                 Some(len) => {
                     string_map.insert(name.to_string(),
-                                      string_table[offset as uint ..
-                                          offset as uint + len].to_vec())
+                                      string_table[offset as usize ..
+                                          offset as usize + len].to_vec())
                 },
                 None => {
                     return Err("invalid file: missing NUL in \

--- a/src/terminfo/searcher.rs
+++ b/src/terminfo/searcher.rs
@@ -12,7 +12,7 @@
 //!
 //! Does not support hashed database, only filesystem!
 
-use std::io::fs::PathExtensions;
+use std::old_io::fs::PathExtensions;
 use std::os::getenv;
 use std::os;
 

--- a/src/terminfo/searcher.rs
+++ b/src/terminfo/searcher.rs
@@ -65,7 +65,7 @@ pub fn get_dbpath_for_term(term: &str) -> Option<Path> {
                 return Some(newp);
             }
             // on some installations the dir is named after the hex of the char (e.g. OS X)
-            let f = format!("{:x}", first_char as uint);
+            let f = format!("{:x}", first_char as usize);
             let newp = p.join_many(&[&f[], term]);
             if newp.exists() {
                 return Some(newp);


### PR DESCRIPTION
This makes term compatible with nightlys again. I didn't migrate to the new `env` because I can't migrate to the new `path` because it's incompatible with `old_io` (and `io` isn't feature complete).