### PR TITLE
Audit integer types.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/",
        html_playground_url = "http://play.rust-lang.org/")]
-#![feature(int_uint, old_io, collections, core, unicode, std_misc, old_path, env)]
+#![feature(old_io, collections, core, unicode, std_misc, old_path, env)]
 #![feature(os)]
 #![deny(missing_docs)]
 

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -149,7 +149,7 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
     fn fg(&mut self, color: color::Color) -> IoResult<bool> {
         let color = self.dim_if_necessary(color);
         if self.num_colors > color {
-            return self.apply_cap("setaf", &[Param::Number(color as int)]);
+            return self.apply_cap("setaf", &[Param::Number(color as isize)]);
         }
         Ok(false)
     }
@@ -157,7 +157,7 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
     fn bg(&mut self, color: color::Color) -> IoResult<bool> {
         let color = self.dim_if_necessary(color);
         if self.num_colors > color {
-            return self.apply_cap("setab", &[Param::Number(color as int)]);
+            return self.apply_cap("setab", &[Param::Number(color as isize)]);
         }
         Ok(false)
     }

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -149,7 +149,7 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
     fn fg(&mut self, color: color::Color) -> IoResult<bool> {
         let color = self.dim_if_necessary(color);
         if self.num_colors > color {
-            return self.apply_cap("setaf", &[Param::Number(color as isize)]);
+            return self.apply_cap("setaf", &[Param::Number(color as i16)]);
         }
         Ok(false)
     }
@@ -157,7 +157,7 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
     fn bg(&mut self, color: color::Color) -> IoResult<bool> {
         let color = self.dim_if_necessary(color);
         if self.num_colors > color {
-            return self.apply_cap("setab", &[Param::Number(color as isize)]);
+            return self.apply_cap("setab", &[Param::Number(color as i16)]);
         }
         Ok(false)
     }

--- a/src/terminfo/parm.rs
+++ b/src/terminfo/parm.rs
@@ -28,12 +28,12 @@ enum States {
     PushParam,
     CharConstant,
     CharClose,
-    IntConstant(int),
+    IntConstant(isize),
     FormatPattern(Flags, FormatState),
-    SeekIfElse(int),
-    SeekIfElsePercent(int),
-    SeekIfEnd(int),
-    SeekIfEndPercent(int)
+    SeekIfElse(isize),
+    SeekIfElsePercent(isize),
+    SeekIfEnd(isize),
+    SeekIfEndPercent(isize)
 }
 
 #[derive(Copy, PartialEq)]
@@ -48,7 +48,7 @@ enum FormatState {
 #[derive(Clone)]
 pub enum Param {
     Words(String),
-    Number(int)
+    Number(isize)
 }
 
 /// Container for static and dynamic variable arrays
@@ -144,7 +144,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     '{' => state = IntConstant(0),
                     'l' => if stack.len() > 0 {
                         match stack.pop().unwrap() {
-                            Words(s) => stack.push(Number(s.len() as int)),
+                            Words(s) => stack.push(Number(s.len() as isize)),
                             _        => return Err("a non-str was used with %l".to_string())
                         }
                     } else { return Err("stack is empty".to_string()) },
@@ -269,7 +269,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                             ' ' => flags.space = true,
                             '.' => fstate = FormatStatePrecision,
                             '0'...'9' => {
-                                flags.width = cur as uint - '0' as uint;
+                                flags.width = cur as usize - '0' as usize;
                                 fstate = FormatStateWidth;
                             }
                             _ => unreachable!()
@@ -306,12 +306,12 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                 if cur >= 'A' && cur <= 'Z' {
                     if stack.len() > 0 {
                         let idx = (cur as u8) - b'A';
-                        vars.sta[idx as uint] = stack.pop().unwrap();
+                        vars.sta[idx as usize] = stack.pop().unwrap();
                     } else { return Err("stack is empty".to_string()) }
                 } else if cur >= 'a' && cur <= 'z' {
                     if stack.len() > 0 {
                         let idx = (cur as u8) - b'a';
-                        vars.dyn[idx as uint] = stack.pop().unwrap();
+                        vars.dyn[idx as usize] = stack.pop().unwrap();
                     } else { return Err("stack is empty".to_string()) }
                 } else {
                     return Err("bad variable name in %P".to_string());
@@ -320,16 +320,16 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
             GetVar => {
                 if cur >= 'A' && cur <= 'Z' {
                     let idx = (cur as u8) - b'A';
-                    stack.push(vars.sta[idx as uint].clone());
+                    stack.push(vars.sta[idx as usize].clone());
                 } else if cur >= 'a' && cur <= 'z' {
                     let idx = (cur as u8) - b'a';
-                    stack.push(vars.dyn[idx as uint].clone());
+                    stack.push(vars.dyn[idx as usize].clone());
                 } else {
                     return Err("bad variable name in %g".to_string());
                 }
             },
             CharConstant => {
-                stack.push(Number(c as int));
+                stack.push(Number(c as isize));
                 state = CharClose;
             },
             CharClose => {
@@ -344,7 +344,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                         state = Nothing;
                     }
                     '0'...'9' => {
-                        state = IntConstant(i*10 + (cur as int - '0' as int));
+                        state = IntConstant(i*10 + (cur as isize - '0' as isize));
                         old_state = Nothing;
                     }
                     _ => return Err("bad int constant".to_string())
@@ -373,7 +373,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                         flags.space = true;
                     }
                     (FormatStateFlags,'0'...'9') => {
-                        flags.width = cur as uint - '0' as uint;
+                        flags.width = cur as usize - '0' as usize;
                         *fstate = FormatStateWidth;
                     }
                     (FormatStateFlags,'.') => {
@@ -381,7 +381,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     }
                     (FormatStateWidth,'0'...'9') => {
                         let old = flags.width;
-                        flags.width = flags.width * 10 + (cur as uint - '0' as uint);
+                        flags.width = flags.width * 10 + (cur as usize - '0' as usize);
                         if flags.width < old { return Err("format width overflow".to_string()) }
                     }
                     (FormatStateWidth,'.') => {
@@ -389,7 +389,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     }
                     (FormatStatePrecision,'0'...'9') => {
                         let old = flags.precision;
-                        flags.precision = flags.precision * 10 + (cur as uint - '0' as uint);
+                        flags.precision = flags.precision * 10 + (cur as usize - '0' as usize);
                         if flags.precision < old {
                             return Err("format precision overflow".to_string())
                         }
@@ -447,8 +447,8 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
 
 #[derive(Copy, PartialEq)]
 struct Flags {
-    width: uint,
-    precision: uint,
+    width: usize,
+    precision: usize,
     alternate: bool,
     left: bool,
     sign: bool,

--- a/src/terminfo/parser/compiled.rs
+++ b/src/terminfo/parser/compiled.rs
@@ -177,34 +177,34 @@ pub fn parse(file: &mut old_io::Reader, longnames: bool)
     let magic = try!(file.read_le_u16());
     if magic != 0x011A {
         return Err(format!("invalid magic number: expected {:x}, found {:x}",
-                           0x011A_us, magic as usize));
+                           0x011A_usize, magic as usize));
     }
 
-    let names_bytes          = try!(file.read_le_i16()) as int;
-    let bools_bytes          = try!(file.read_le_i16()) as int;
-    let numbers_count        = try!(file.read_le_i16()) as int;
-    let string_offsets_count = try!(file.read_le_i16()) as int;
-    let string_table_bytes   = try!(file.read_le_i16()) as int;
+    let names_bytes          = try!(file.read_le_i16()) as isize;
+    let bools_bytes          = try!(file.read_le_i16()) as isize;
+    let numbers_count        = try!(file.read_le_i16()) as isize;
+    let string_offsets_count = try!(file.read_le_i16()) as isize;
+    let string_table_bytes   = try!(file.read_le_i16()) as isize;
 
     assert!(names_bytes > 0);
 
-    if (bools_bytes as uint) > boolnames.len() {
+    if (bools_bytes as usize) > boolnames.len() {
         return Err("incompatible file: more booleans than \
                     expected".to_string());
     }
 
-    if (numbers_count as uint) > numnames.len() {
+    if (numbers_count as usize) > numnames.len() {
         return Err("incompatible file: more numbers than \
                     expected".to_string());
     }
 
-    if (string_offsets_count as uint) > stringnames.len() {
+    if (string_offsets_count as usize) > stringnames.len() {
         return Err("incompatible file: more string offsets than \
                     expected".to_string());
     }
 
     // don't read NUL
-    let bytes = try!(file.read_exact(names_bytes as uint - 1));
+    let bytes = try!(file.read_exact(names_bytes as usize - 1));
     let names_str = match String::from_utf8(bytes) {
         Ok(s)  => s,
         Err(_) => return Err("input not utf-8".to_string()),
@@ -221,7 +221,7 @@ pub fn parse(file: &mut old_io::Reader, longnames: bool)
         for i in range(0, bools_bytes) {
             let b = try!(file.read_byte());
             if b == 1 {
-                bools_map.insert(bnames[i as uint].to_string(), true);
+                bools_map.insert(bnames[i as usize].to_string(), true);
             }
         }
     }
@@ -235,7 +235,7 @@ pub fn parse(file: &mut old_io::Reader, longnames: bool)
         for i in range(0, numbers_count) {
             let n = try!(file.read_le_u16());
             if n != 0xFFFF {
-                numbers_map.insert(nnames[i as uint].to_string(), n);
+                numbers_map.insert(nnames[i as usize].to_string(), n);
             }
         }
     }
@@ -248,9 +248,9 @@ pub fn parse(file: &mut old_io::Reader, longnames: bool)
             string_offsets.push(try!(file.read_le_u16()));
         }
 
-        let string_table = try!(file.read_exact(string_table_bytes as uint));
+        let string_table = try!(file.read_exact(string_table_bytes as usize));
 
-        if string_table.len() != string_table_bytes as uint {
+        if string_table.len() != string_table_bytes as usize {
             return Err("error: hit EOF before end of string \
                         table".to_string());
         }
@@ -276,13 +276,13 @@ pub fn parse(file: &mut old_io::Reader, longnames: bool)
 
 
             // Find the offset of the NUL we want to go to
-            let nulpos = string_table[offset as uint .. string_table_bytes as uint]
+            let nulpos = string_table[offset as usize .. string_table_bytes as usize]
                 .iter().position(|&b| b == 0);
             match nulpos {
                 Some(len) => {
                     string_map.insert(name.to_string(),
-                                      string_table[offset as uint ..
-                                          offset as uint + len].to_vec())
+                                      string_table[offset as usize ..
+                                          offset as usize + len].to_vec())
                 },
                 None => {
                     return Err("invalid file: missing NUL in \

--- a/src/terminfo/searcher.rs
+++ b/src/terminfo/searcher.rs
@@ -65,7 +65,7 @@ pub fn get_dbpath_for_term(term: &str) -> Option<Path> {
                 return Some(newp);
             }
             // on some installations the dir is named after the hex of the char (e.g. OS X)
-            let f: &str = &format!("{:x}", first_char as uint);
+            let f: &str = &format!("{:x}", first_char as usize);
             let newp = p.join_many(&[f, term]);
             if newp.exists() {
                 return Some(newp);


### PR DESCRIPTION
Basically, use isize/usize instead of int/uint and then replace instances of isize/usize with the correct integer widths where appropriate.