### PR TITLE
term no longer depends on log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ description = """
 A terminal formatting library
 """
 
-[dependencies]
-log = "0.2.0"
-
 [target.i686-pc-windows-gnu.dependencies]
 winapi = "*"
 kernel32-sys = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,6 @@
 #![feature(os)]
 #![deny(missing_docs)]
 
-#[macro_use] extern crate log;
-
 pub use terminfo::TerminfoTerminal;
 #[cfg(windows)]
 pub use win::WinConsole;


### PR DESCRIPTION
All error information is returned to the application via Results.