### PR TITLE
Port to new io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ description = """
 A terminal formatting library
 """
 
+[dependencies]
+byteorder = "*"
+
 [target.i686-pc-windows-gnu.dependencies]
 winapi = "*"
 kernel32-sys = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! ```no_run
 //! extern crate term;
-//! use std::io::Write;
+//! use std::io::prelude::*;
 //!
 //! fn main() {
 //!     let mut t = term::stdout().unwrap();
@@ -48,11 +48,14 @@
 
 extern crate byteorder;
 
+// prelude
+use std::io::prelude::*;
+
 pub use terminfo::TerminfoTerminal;
 #[cfg(windows)]
 pub use win::WinConsole;
 
-use std::io::{self, Stdout, Stderr, Write};
+use std::io::{self, Stdout, Stderr};
 
 pub mod terminfo;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/",
        html_playground_url = "http://play.rust-lang.org/")]
-#![feature(collections, core, unicode, std_misc, io, path, path_ext)]
+#![feature(collections, core, unicode, std_misc, io, path_ext)]
 #![deny(missing_docs)]
 
 extern crate byteorder;

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -10,12 +10,15 @@
 
 //! Terminfo database interface.
 
+// Prelude
+use std::io::prelude::*;
+use std::path::Path;
+
 use std::collections::HashMap;
 use std::error::Error as ErrorTrait;
 use std::{fmt, env};
-use std::io::{self, Write};
+use std::io;
 use std::fs::File;
-use std::path::Path;
 
 use Attr;
 use color;

--- a/src/terminfo/searcher.rs
+++ b/src/terminfo/searcher.rs
@@ -12,7 +12,9 @@
 //!
 //! Does not support hashed database, only filesystem!
 
-use std::fs::PathExt;
+// Prelude
+use std::io::prelude::*;
+
 use std::env;
 use std::path::PathBuf;
 

--- a/src/win.rs
+++ b/src/win.rs
@@ -15,7 +15,10 @@
 extern crate "kernel32-sys" as kernel32;
 extern crate winapi;
 
-use std::io::{self, Write};
+// Prelude
+use std::io::prelude::*;
+
+use std::io;
 
 use Attr;
 use color;

--- a/src/win.rs
+++ b/src/win.rs
@@ -15,7 +15,7 @@
 extern crate "kernel32-sys" as kernel32;
 extern crate winapi;
 
-use std::old_io::IoResult;
+use std::io::{self, Write};
 
 use Attr;
 use color;
@@ -68,7 +68,7 @@ fn bits_to_color(bits: u16) -> color::Color {
     color | (bits & 0x8) // copy the hi-intensity bit
 }
 
-impl<T: Writer+Send> WinConsole<T> {
+impl<T: Write+Send> WinConsole<T> {
     fn apply(&mut self) {
         let _unused = self.buf.flush();
         let mut accum: winapi::WORD = 0;
@@ -116,32 +116,32 @@ impl<T: Writer+Send> WinConsole<T> {
     }
 }
 
-impl<T: Writer> Writer for WinConsole<T> {
-    fn write_all(&mut self, buf: &[u8]) -> IoResult<()> {
-        self.buf.write_all(buf)
+impl<T: Write> Write for WinConsole<T> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.write(buf)
     }
 
-    fn flush(&mut self) -> IoResult<()> {
+    fn flush(&mut self) -> io::Result<()> {
         self.buf.flush()
     }
 }
 
-impl<T: Writer+Send> Terminal<T> for WinConsole<T> {
-    fn fg(&mut self, color: color::Color) -> IoResult<bool> {
+impl<T: Write+Send> Terminal<T> for WinConsole<T> {
+    fn fg(&mut self, color: color::Color) -> io::Result<bool> {
         self.foreground = color;
         self.apply();
 
         Ok(true)
     }
 
-    fn bg(&mut self, color: color::Color) -> IoResult<bool> {
+    fn bg(&mut self, color: color::Color) -> io::Result<bool> {
         self.background = color;
         self.apply();
 
         Ok(true)
     }
 
-    fn attr(&mut self, attr: Attr) -> IoResult<bool> {
+    fn attr(&mut self, attr: Attr) -> io::Result<bool> {
         match attr {
             Attr::ForegroundColor(f) => {
                 self.foreground = f;
@@ -166,7 +166,7 @@ impl<T: Writer+Send> Terminal<T> for WinConsole<T> {
         }
     }
 
-    fn reset(&mut self) -> IoResult<bool> {
+    fn reset(&mut self) -> io::Result<bool> {
         self.foreground = self.def_foreground;
         self.background = self.def_background;
         self.apply();
@@ -179,6 +179,6 @@ impl<T: Writer+Send> Terminal<T> for WinConsole<T> {
     fn get_mut<'a>(&'a mut self) -> &'a mut T { &mut self.buf }
 }
 
-impl<T: Writer+Send> UnwrappableTerminal<T> for WinConsole<T> {
+impl<T: Write+Send> UnwrappableTerminal<T> for WinConsole<T> {
     fn unwrap(self) -> T { self.buf }
 }


### PR DESCRIPTION
This is a port to the new io, fs, and path modules AND SHOULD NOT BE MERGED YET. I'm posting it now for feedback (and because I wanted to test out the new io API).

1. Is relying on a third party library, byteorder, ok?
2. I currently re-use PathBufs. Should I just reallocate new ones?

Somewhat off topic (should I put these on internals?):

1. Is OsStr/OsString likely to gain a split method? Currently, term can't handle non-utf8 TERMINFO paths because because I couldn't replace `env::var` with `env::var_os` because I needed `Str::split`.
2. Will `ReadExt` likely gain a method like the `read_harder` that I defined here? The byte-order crate also implements a similar method.