### PR TITLE
Fix warnings on the latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/",
        html_playground_url = "http://play.rust-lang.org/")]
-#![feature(core, io, convert)]
+#![feature(io, convert)]
 #![deny(missing_docs)]
 
 use std::io::prelude::*;

--- a/src/terminfo/parm.rs
+++ b/src/terminfo/parm.rs
@@ -18,7 +18,6 @@ use self::FormatOp::*;
 use std::ascii::AsciiExt;
 use std::iter::repeat;
 use std::mem::replace;
-use std::num::Int;
 
 #[derive(Copy, PartialEq)]
 enum States {

--- a/src/terminfo/searcher.rs
+++ b/src/terminfo/searcher.rs
@@ -27,7 +27,7 @@ pub fn get_dbpath_for_term(term: &str) -> Option<PathBuf> {
 
     // Find search directory
     match env::var_os("TERMINFO") {
-        Some(dir) => dirs_to_search.push(PathBuf::from(&dir)),
+        Some(dir) => dirs_to_search.push(PathBuf::from(dir)),
         None => {
             if let Some(mut homedir) = env::home_dir() {
                 // ncurses compatibility;


### PR DESCRIPTION
Additionally, remove an unnecessary allocation (piggy backing on this PR
because it doesn't warrant its own PR).