### PR TITLE
Add terminfo implementation for animating output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,12 @@ pub trait Terminal<T: Write>: Write {
     /// if there was an I/O error.
     fn delete_line(&mut self) -> io::Result<bool>;
 
+    /// Moves the cursor to the left edge of the current line.
+    ///
+    /// Returns `Ok(true)` if the text was deleted, `Ok(false)` otherwise, and `Err(e)`
+    /// if there was an I/O error.
+    fn carriage_return(&mut self) -> io::Result<bool>;
+
     /// Gets an immutable reference to the stream inside
     fn get_ref<'a>(&'a self) -> &'a T;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,18 @@ pub trait Terminal<T: Write>: Write {
     /// was an I/O error.
     fn reset(&mut self) -> io::Result<bool>;
 
+    /// Moves the cursor up one line.
+    ///
+    /// Returns `Ok(true)` if the cursor was moved, `Ok(false)` otherwise, and `Err(e)`
+    /// if there was an I/O error.
+    fn cursor_up(&mut self) -> io::Result<bool>;
+
+    /// Deletes the text from the cursor location to the end of the line.
+    ///
+    /// Returns `Ok(true)` if the text was deleted, `Ok(false)` otherwise, and `Err(e)`
+    /// if there was an I/O error.
+    fn delete_line(&mut self) -> io::Result<bool>;
+
     /// Gets an immutable reference to the stream inside
     fn get_ref<'a>(&'a self) -> &'a T;
 

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -213,6 +213,10 @@ impl<T: Write+Send> Terminal<T> for TerminfoTerminal<T> {
         self.apply_cap("dl", &[])
     }
 
+    fn carriage_return(&mut self) -> io::Result<bool> {
+        self.apply_cap("cr", &[])
+    }
+
     fn get_ref<'a>(&'a self) -> &'a T { &self.out }
 
     fn get_mut<'a>(&'a mut self) -> &'a mut T { &mut self.out }

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -205,6 +205,14 @@ impl<T: Write+Send> Terminal<T> for TerminfoTerminal<T> {
         self.out.write_all(&cmd).map(|_|true)
     }
 
+    fn cursor_up(&mut self) -> io::Result<bool> {
+        self.apply_cap("cuu1", &[])
+    }
+
+    fn delete_line(&mut self) -> io::Result<bool> {
+        self.apply_cap("dl", &[])
+    }
+
     fn get_ref<'a>(&'a self) -> &'a T { &self.out }
 
     fn get_mut<'a>(&'a mut self) -> &'a mut T { &mut self.out }


### PR DESCRIPTION
This proposal adds the terminfo implementations of three commands: `cursor_up`, `delete_line`, and `carriage_return`. These three commands provide the building blocks for implementing animated terminal output.

I wrote a [a sample program](https://github.com/asolove/rust-playground/blob/local-term/src/main.rs) that shows how to use these commands to create pretty console progress updates and an animated spinner.

*For your consideration*:

- In #11, @retep998 graciously offered to implement the Windows versions, but I may also take a crack at it tomorrow.
- I have hard-coded the terminfo strings for these three commands rather than adding them to the `Attr` enum, because they are commands rather than attributes. I think there is an argument to be made for either renaming `Attr` to `Command` or adding these commands into it either way, but wanted to ask someone more knowledgeable for their advice before doing so.
- The name of the command `carriage_return` is potentially confusing since \r has different behavior on different systems, but the terminfo docs make clear that terminals should implement this command by moving the cursor to the far left of the current line. It should possibly be renamed something like `cursor_far_left`.
- I didn't write any tests because I wasn't sure how to do so in a meaningful way.