### PR TITLE
Implement Deref for terminals.

### DIFF
--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -17,6 +17,7 @@ use std::fmt;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io;
+use std::ops::{Deref, DerefMut};
 use std::path::Path;
 
 use Attr;
@@ -150,7 +151,7 @@ pub struct TerminfoTerminal<T> {
     ti: TermInfo,
 }
 
-impl<T: Write+Send> Terminal<T> for TerminfoTerminal<T> {
+impl<T: Write+Send> Terminal for TerminfoTerminal<T> {
     fn fg(&mut self, color: color::Color) -> io::Result<bool> {
         let color = self.dim_if_necessary(color);
         if self.num_colors > color {
@@ -216,13 +217,22 @@ impl<T: Write+Send> Terminal<T> for TerminfoTerminal<T> {
     fn carriage_return(&mut self) -> io::Result<bool> {
         self.apply_cap("cr", &[])
     }
-
-    fn get_ref<'a>(&'a self) -> &'a T { &self.out }
-
-    fn get_mut<'a>(&'a mut self) -> &'a mut T { &mut self.out }
 }
 
-impl<T: Write+Send> UnwrappableTerminal<T> for TerminfoTerminal<T> {
+impl<T> Deref for TerminfoTerminal<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.out
+    }
+}
+
+impl<T> DerefMut for TerminfoTerminal<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.out
+    }
+}
+
+impl<T: Write+Send> UnwrappableTerminal for TerminfoTerminal<T> {
     fn unwrap(self) -> T { self.out }
 }
 

--- a/src/win.rs
+++ b/src/win.rs
@@ -19,6 +19,7 @@ use std::ffi::OsStr;
 use std::io::prelude::*;
 use std::io;
 use std::os::windows::ffi::OsStrExt;
+use std::ops::{Deref, DerefMut};
 use std::ptr;
 
 use Attr;
@@ -148,7 +149,7 @@ impl<T: Write> Write for WinConsole<T> {
     }
 }
 
-impl<T: Write+Send> Terminal<T> for WinConsole<T> {
+impl<T: Write+Send> Terminal for WinConsole<T> {
     fn fg(&mut self, color: color::Color) -> io::Result<bool> {
         self.foreground = color;
         try!(self.apply());
@@ -263,12 +264,21 @@ impl<T: Write+Send> Terminal<T> for WinConsole<T> {
             }
         }
     }
-
-    fn get_ref<'a>(&'a self) -> &'a T { &self.buf }
-
-    fn get_mut<'a>(&'a mut self) -> &'a mut T { &mut self.buf }
 }
 
-impl<T: Write+Send> UnwrappableTerminal<T> for WinConsole<T> {
+impl<T> Deref for WinConsole<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.out
+    }
+}
+
+impl<T> DerefMut for WinConsole<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.out
+    }
+}
+
+impl<T: Write+Send> UnwrappableTerminal for WinConsole<T> {
     fn unwrap(self) -> T { self.buf }
 }


### PR DESCRIPTION
Also, instead of using a type parameter, use Deref::Target to store the
Write type. IMHO, this should be an associated type on `Terminal` itself
however, that would cause a circular dependency.

[breaking-change]