### PR TITLE
Clean up unwrap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,10 +219,7 @@ pub trait Terminal: Write {
 
     /// Gets a mutable reference to the stream inside
     fn get_mut<'a>(&'a mut self) -> &'a mut Self::Output;
-}
 
-/// A terminal which can be unwrapped.
-pub trait UnwrappableTerminal: Terminal {
     /// Returns the contained stream, destroying the `Terminal`
-    fn unwrap(self) -> Self::Output;
+    fn unwrap(self) -> Self::Output where Self: Sized;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,5 +221,5 @@ pub trait Terminal: Write {
     fn get_mut<'a>(&'a mut self) -> &'a mut Self::Output;
 
     /// Returns the contained stream, destroying the `Terminal`
-    fn unwrap(self) -> Self::Output where Self: Sized;
+    fn into_inner(self) -> Self::Output where Self: Sized;
 }

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -221,7 +221,7 @@ impl<T: Write+Send> Terminal for TerminfoTerminal<T> {
 
     fn get_mut<'a>(&'a mut self) -> &'a mut T { &mut self.out }
 
-    fn unwrap(self) -> T where Self: Sized { self.out }
+    fn into_inner(self) -> T where Self: Sized { self.out }
 }
 
 impl<T: Write+Send> TerminfoTerminal<T> {

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -22,7 +22,6 @@ use std::path::Path;
 use Attr;
 use color;
 use Terminal;
-use UnwrappableTerminal;
 use self::searcher::get_dbpath_for_term;
 use self::parser::compiled::{parse, msys_terminfo};
 use self::parm::{expand, Variables, Param};
@@ -221,10 +220,8 @@ impl<T: Write+Send> Terminal for TerminfoTerminal<T> {
     fn get_ref<'a>(&'a self) -> &'a T { &self.out }
 
     fn get_mut<'a>(&'a mut self) -> &'a mut T { &mut self.out }
-}
 
-impl<T: Write+Send> UnwrappableTerminal for TerminfoTerminal<T> {
-    fn unwrap(self) -> T { self.out }
+    fn unwrap(self) -> T where Self: Sized { self.out }
 }
 
 impl<T: Write+Send> TerminfoTerminal<T> {

--- a/src/win.rs
+++ b/src/win.rs
@@ -270,5 +270,5 @@ impl<T: Write+Send> Terminal for WinConsole<T> {
 
     fn get_mut<'a>(&'a mut self) -> &'a mut T { &mut self.buf }
 
-    fn unwrap(self) -> T where Self: Sized { self.buf }
+    fn into_inner(self) -> T where Self: Sized { self.buf }
 }

--- a/src/win.rs
+++ b/src/win.rs
@@ -23,7 +23,7 @@ use std::ptr;
 
 use Attr;
 use color;
-use {Terminal, UnwrappableTerminal};
+use Terminal;
 
 /// A Terminal implementation which uses the Win32 Console API.
 pub struct WinConsole<T> {
@@ -269,8 +269,6 @@ impl<T: Write+Send> Terminal for WinConsole<T> {
     fn get_ref<'a>(&'a self) -> &'a T { &self.buf }
 
     fn get_mut<'a>(&'a mut self) -> &'a mut T { &mut self.buf }
-}
 
-impl<T: Write+Send> UnwrappableTerminal for WinConsole<T> {
-    fn unwrap(self) -> T { self.buf }
+    fn unwrap(self) -> T where Self: Sized { self.buf }
 }


### PR DESCRIPTION
Remove UnwrappableTerminal trait and rename unwrap to into_inner. As far as I
know, the trait existed to make Terminal object safe but that's no longer an
issue as one can specify `Self: Sized` on object unsafe methods.