### PR TITLE
Allow missing docs for various statics and constants.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ pub fn stderr() -> Option<Box<StderrTerminal>> {
 
 
 /// Terminal color definitions
+#[allow(missing_docs)]
 pub mod color {
     /// Number for a terminal color
     pub type Color = u16;

--- a/src/terminfo/parser/compiled.rs
+++ b/src/terminfo/parser/compiled.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(non_upper_case_globals)]
+#![allow(non_upper_case_globals, missing_docs)]
 
 //! ncurses-compatible compiled terminfo format parsing (term(5))
 


### PR DESCRIPTION
This fixes lint errors when using the latest nightly `rustc 1.3.0-nightly (20f421cd5 2015-07-06)`.

I guess the statics shouldn't really be documented and the constants are pretty self-explanatory.