### PR TITLE
Only depend on kernel32 and winapi on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,18 @@ description = """
 A terminal formatting library
 """
 
-[dependencies]
+[target.i686-pc-windows-gnu.dependencies]
+winapi = "0.2"
+kernel32-sys = "0.1"
+
+[target.i686-pc-windows-msvc.dependencies]
+winapi = "0.2"
+kernel32-sys = "0.1"
+
+[target.x86_64-pc-windows-gnu.dependencies]
+winapi = "0.2"
+kernel32-sys = "0.1"
+
+[target.x86_64-pc-windows-msvc.dependencies]
 winapi = "0.2"
 kernel32-sys = "0.1"


### PR DESCRIPTION
`kernel32` and `winapi` are completely pointless for non-Windows builds. (They’re empty crates on non-Windows owing to a `#![cfg(windows)]` crate attribute so that they build.) They shouldn’t even be depended on for non-Windows builds.

The duplication is ugly, but necessary for now; see also https://github.com/rust-lang/cargo/issues/1007